### PR TITLE
Dataloader adapter to feed the tokens to the model

### DIFF
--- a/cfgs/nano4M/multiclevr_d6-6w512.yaml
+++ b/cfgs/nano4M/multiclevr_d6-6w512.yaml
@@ -6,9 +6,9 @@ output_dir: ./outputs/auto # Set to auto to use the run_name
 # Global variables used throughout the config
 global_vars:
   batch_size: 128 # per GPU (512 global batch size)
-  modalities: ["tok_rgb@256", "tok_depth@256", "tok_normal@256", "scene_desc"] # Input and output modalities
-  vocab_sizes: [64000, 64000, 64000, 50304] # Vocab sizes for each modality
-  max_seq_lens: [256, 256, 256, 256] # Max sequence lengths for each modality
+  modalities: ["tok_rgb@256", "tok_depth@256", "tok_normal@256","video","audio", "scene_desc"] # TODO: adapt Input and output modalities
+  vocab_sizes: [64000, 64000, 64000, 50304] # TODO: adapt Vocab sizes for each modality
+  max_seq_lens: [256, 256, 256, 256] #TODO: adjust per-modality max token counts
   input_alphas: [1.0, 1.0, 1.0, 1.0] # Input dirichlet alpha values for each modality
   target_alphas: [1.0, 1.0, 1.0, 1.0] # Target dirichlet alpha values for each modality
   input_tokens_range: [1, 128] # Min and max encoder tokens during training
@@ -18,7 +18,7 @@ global_vars:
 batch_size: ${global_vars.batch_size}
 total_tokens: 5000 # in millions of tokens
 warmup_tokens: 500 # in millions of tokens
-num_tokens_per_sample: 256 # Number of tokens per sample to count towards the total tokens seen. 128 in + 128 out
+num_tokens_per_sample: 256 #TODO set to total input+output token budget# Number of tokens per sample to count towards the total tokens seen. 128 in + 128 out
 lr: 0.0006 # Max learning rate
 min_lr: 0.000001 # Min learning rate after cosine decay
 weight_decay: 0.05 # AdamW weight decay

--- a/cfgs/nano4M/multiclevr_d6-6w512.yaml
+++ b/cfgs/nano4M/multiclevr_d6-6w512.yaml
@@ -6,8 +6,8 @@ output_dir: ./outputs/auto # Set to auto to use the run_name
 # Global variables used throughout the config
 global_vars:
   batch_size: 128 # per GPU (512 global batch size)
-  modalities: ["tok_rgb@256", "tok_depth@256", "tok_normal@256","video","audio", "scene_desc"] # TODO: adapt Input and output modalities
-  vocab_sizes: [64000, 64000, 64000, 50304] # TODO: adapt Vocab sizes for each modality
+  modalities: ["tok_rgb@256", "tok_depth@256",'tok_audio', 'tok_videof1','tok_videof2', 'tok_videof3', 'tok_videof4','tok_videof5', "scene_desc"] # TODO: adapt Input and output modalities
+  vocab_sizes: [64000, 64000, 64000,50304] # TODO: adapt Vocab sizes for each modality
   max_seq_lens: [256, 256, 256, 256] #TODO: adjust per-modality max token counts
   input_alphas: [1.0, 1.0, 1.0, 1.0] # Input dirichlet alpha values for each modality
   target_alphas: [1.0, 1.0, 1.0, 1.0] # Target dirichlet alpha values for each modality

--- a/nanofm/data/multimodal/__init__.py
+++ b/nanofm/data/multimodal/__init__.py
@@ -84,33 +84,8 @@ def create_multimodal_masked_dataloader(
         overlap_posembs=overlap_posembs,
     )
     def combined_transforms(data_dict):
-        """
-        Applique d'abord le masking MLM sur tok_* et scene_desc,
-        puis un zero-out simple sur video et audio.
-        """
-        #MLM masking pour tok_* et scene_desc
         masked = masking_transforms(data_dict)
-        ## TODO: Review the masking logic for video and audio
-        #Video: masquer 15% des frames en les remplaçant par 0
-        if 'video' in masked:
-            vid = masked['video']               # Tensor shape: (T, H, W, C) ou similaire
-            n_frames = vid.size(0)
-            n_mask   = max(1, int(n_frames * 0.15))
-            mask_idx = torch.randperm(n_frames)[:n_mask]
-            vid = vid.clone()
-            vid[mask_idx, ...] = 0
-            masked['video'] = vid
-
-        # 3) Audio : masquer 15% des pas temporels
-        if 'audio' in masked:
-            aud     = masked['audio']           # Tensor shape: (T, F) ou similaire
-            n_steps = aud.size(0)
-            n_mask  = max(1, int(n_steps * 0.15))
-            mask_idx = torch.randperm(n_steps)[:n_mask]
-            aud = aud.clone()
-            aud[mask_idx, ...] = 0
-            masked['audio'] = aud
-
+        #We will add here the masking logic of the tokens of video and audio if needed
         return masked
 
     dataset = AdaptedMultimodalDataset(

--- a/nanofm/data/multimodal/adapted_multimodal_dataset.py
+++ b/nanofm/data/multimodal/adapted_multimodal_dataset.py
@@ -111,7 +111,7 @@ class AdaptedMultimodalDataset(Dataset):
             ext = self.modality_extensions[modality]
             file_path = os.path.join(self.root_dir, self.split, modality, f"{file_name}{ext}")
 
-            if 'tok' in modality:
+            if  modality in ['tok_audio', 'tok_videof1','tok_videof2', 'tok_videof3', 'tok_videof4','tok_videof5'] :
                 data = np.load(file_path)[augmentation_idx]
                 tensor = torch.from_numpy(data).long()
             elif modality in ['video','audio']:

--- a/nanofm/data/multimodal/adapted_multimodal_dataset.py
+++ b/nanofm/data/multimodal/adapted_multimodal_dataset.py
@@ -1,0 +1,137 @@
+# Copyright 2025 EPFL
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List, Callable, Optional
+import os
+from pathlib import Path
+import json
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+from transformers import AutoTokenizer
+from tokenizers.processors import TemplateProcessing
+
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
+
+class AdaptedMultimodalDataset(Dataset):
+    def __init__(
+            self,
+            root_dir: str,
+            split: str,
+            modalities: List[str],
+            transforms: Optional[Callable] = None,
+            sample_from_k_augmentations: int = 10,
+            text_tokenizer_path: str = 'gpt2',
+            text_max_length: int = 256,
+    ):
+        """
+        Simple multimodal dataset.
+
+        Assumptions:
+        - Each modality contains the same filenames in {root_dir}/{split}/{modality}/{file_name}.{ext}
+        - Tokenized data is saved as .npy files and captions are saved as .json files
+        - Each sample contains K random augmentations. The k-th augmentations are aligned across modalities.
+
+        Args:
+            root_dir: Root directory of the dataset.
+            split: Split of the dataset (train, val, test).
+            modalities: List of modalities.
+            transforms: Transformations to apply to the data_dict before returning.
+            sample_from_k_augmentations: Number of augmentations to sample from. If K=1, no augmentations are sampled,
+                and only the "center crop" version is used. K is the total number of versions for each sample.
+            text_tokenizer_path: Path or HuggingFace Hub ID of the text tokenizer, e.g. gpt2.
+            text_max_length: Maximum length of the text.
+        """
+        self.root_dir = root_dir
+        self.split = split
+        self.modalities = modalities
+        self.transforms = transforms
+        self.sample_from_k_augmentations = sample_from_k_augmentations
+
+        self.file_names = self._get_file_names()
+        self.modality_extensions = self._get_modality_extensions()
+
+        self.text_tokenizer_path = text_tokenizer_path
+        self.text_max_length = text_max_length
+        self.text_tokenizer = self._get_text_tokenizer()
+
+    def __len__(self):
+        return len(self.file_names)
+
+    def _get_file_names(self):
+        # Get all filenames. We assume the dataset is fully aligned across all modalities.
+        file_names = [
+            Path(file_path).stem
+            for file_path in os.listdir(os.path.join(self.root_dir, self.split, self.modalities[0]))
+        ]
+        return sorted(file_names)
+
+    def _get_modality_extensions(self):
+        # Get file extension for all modalities
+        extensions = {}
+        for modality in self.modalities:
+            modality_dir = Path(os.path.join(self.root_dir, self.split, modality))
+            first_file = next(modality_dir.glob('*'))
+            extensions[modality] = first_file.suffix
+        return extensions
+
+    def _get_text_tokenizer(self):
+        tokenizer = AutoTokenizer.from_pretrained(self.text_tokenizer_path)
+        tokenizer.add_special_tokens({'pad_token': '[PAD]'})
+        tokenizer.add_special_tokens({
+            'bos_token': '[SOS]',
+            'eos_token': '[EOS]',
+        })
+        tokenizer._tokenizer.post_processor = TemplateProcessing(
+            single="[SOS] $A [EOS]",
+            special_tokens=[('[EOS]', tokenizer.eos_token_id), ('[SOS]', tokenizer.bos_token_id)],
+        )
+        return tokenizer
+
+    def __getitem__(self, idx):
+        file_name = self.file_names[idx]
+
+        data_dict = {}
+
+        augmentation_idx = np.random.randint(0, self.sample_from_k_augmentations)
+
+        for modality in self.modalities:
+            ext = self.modality_extensions[modality]
+            file_path = os.path.join(self.root_dir, self.split, modality, f"{file_name}{ext}")
+
+            if 'tok' in modality:
+                data = np.load(file_path)[augmentation_idx]
+                tensor = torch.from_numpy(data).long()
+            elif modality in ['video','audio']:
+                data = np.load(file_path)[augmentation_idx]
+                tensor = torch.from_numpy(data).long()
+            elif 'scene_desc' in modality:
+                with open(file_path, 'r') as f:
+                    captions = json.load(f)
+                caption = captions[augmentation_idx]
+                tokenized = self.text_tokenizer(
+                    caption, max_length=self.text_max_length, padding='max_length',
+                    truncation=True, return_tensors='pt'
+                )
+                tensor = tokenized['input_ids'][0]
+            else:
+                raise ValueError(f"Unknown modality: {modality}")
+
+            data_dict[modality] = tensor
+
+        if self.transforms:
+            data_dict = self.transforms(data_dict)
+
+        return data_dict


### PR DESCRIPTION
New class added : AdaptedMultimodalDataset which ensures that we can train without changing the structure of the .yaml config file while making sure to train on the tokens of video and audio as well.
nanofm/data/multimodal/__init__.py changed to allow the same goal.
cfgs/nano4M/multiclevr_d6-6w512.yaml changed but still needs to be adjusted in fonction of the tokens that we obtain